### PR TITLE
change graph url to depricated version

### DIFF
--- a/GETDiscordBot/thegraph/getchart.py
+++ b/GETDiscordBot/thegraph/getchart.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 
 graphurl = \
-    "https://api.thegraph.com/subgraphs/name/getprotocol/get-protocol-subgraph"
+    "https://api.thegraph.com/subgraphs/name/getprotocol/get-protocol-subgraph-deprecated"
 
 
 def queryGraph(days, skiplastday = False):


### PR DESCRIPTION
Changed graph url to deprecated version, because the program isn't compatible.